### PR TITLE
Emphasize Scripting aspect, remove direct Path usage

### DIFF
--- a/src/main/java/net/neoforged/coremod/CoreMod.java
+++ b/src/main/java/net/neoforged/coremod/CoreMod.java
@@ -13,27 +13,26 @@ import org.objectweb.asm.tree.MethodNode;
 
 import javax.script.*;
 import java.io.*;
-import java.nio.file.*;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.*;
 
 public class CoreMod {
     public static final Marker COREMODLOG = MarkerManager.getMarker("COREMODLOG").addParents(MarkerManager.getMarker("COREMOD"));
-    private final ICoreModFile file;
+    private final ICoreModScriptSource file;
     private final ScriptEngine scriptEngine;
     private Map<String, ? extends Bindings> javaScript;
     private boolean loaded = false;
     private Exception error;
     private Logger logger;
 
-    CoreMod(final ICoreModFile file, final ScriptEngine scriptEngine) {
+    CoreMod(final ICoreModScriptSource file, final ScriptEngine scriptEngine) {
         this.file = file;
         this.scriptEngine = scriptEngine;
     }
 
-    public Path getPath() {
-        return this.file.getPath();
+    public String getDebugSource() {
+        return this.file.getDebugSource();
     }
 
     @SuppressWarnings("unchecked")
@@ -94,7 +93,7 @@ public class CoreMod {
         return error;
     }
 
-    public ICoreModFile getFile() {
+    public ICoreModScriptSource getFile() {
         return file;
     }
 

--- a/src/main/java/net/neoforged/coremod/CoreModScriptingEngine.java
+++ b/src/main/java/net/neoforged/coremod/CoreModScriptingEngine.java
@@ -10,7 +10,7 @@ import javax.script.*;
 import java.util.*;
 import java.util.stream.*;
 
-public class CoreModEngine {
+public class CoreModScriptingEngine {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Marker COREMOD = MarkerManager.getMarker("COREMOD");
     private List<CoreMod> coreMods = new ArrayList<>();
@@ -46,7 +46,7 @@ public class CoreModEngine {
             "org.objectweb.asm.Label","org.objectweb.asm.Type",
             "org.objectweb.asm.TypePath","org.objectweb.asm.TypeReference"
     ));
-    public void loadCoreMod(ICoreModFile coremod) {
+    public void loadCoreMod(ICoreModScriptSource coremod) {
         // We have a factory per coremod, to provide namespace and functional isolation between coremods
         final ScriptEngine scriptEngine = NashornFactory.createEngine();
         final ScriptContext jsContext = scriptEngine.getContext();
@@ -70,7 +70,7 @@ public class CoreModEngine {
     }
 
     private void initialize(final CoreMod coreMod) {
-        LOGGER.debug(COREMOD,"Loading CoreMod from {}", coreMod.getPath());
+        LOGGER.debug(COREMOD,"Loading CoreMod from {}", coreMod.getDebugSource());
         coreMod.initialize();
         if (coreMod.hasError()) {
             LOGGER.error(COREMOD,"Error occurred initializing CoreMod", coreMod.getError());

--- a/src/main/java/net/neoforged/coremod/ICoreModScriptSource.java
+++ b/src/main/java/net/neoforged/coremod/ICoreModScriptSource.java
@@ -6,15 +6,14 @@ package net.neoforged.coremod;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.nio.file.Path;
 
 /**
  * Interface for core mods to discover content and properties
  * of their location and context to the coremod implementation.
  */
-public interface ICoreModFile {
+public interface ICoreModScriptSource {
     String getOwnerId();
     Reader readCoreMod() throws IOException;
-    Path getPath();
     Reader getAdditionalFile(final String fileName) throws IOException;
+    String getDebugSource();
 }

--- a/src/main/java/net/neoforged/coremod/NashornFactory.java
+++ b/src/main/java/net/neoforged/coremod/NashornFactory.java
@@ -11,7 +11,7 @@ import org.openjdk.nashorn.api.scripting.ScriptObjectMirror;
 class NashornFactory {
     private static final String[] ARGS = new String[] {"--language=es6"};
     static ScriptEngine createEngine() {
-        return new NashornScriptEngineFactory().getScriptEngine(ARGS, getAppClassLoader(), CoreModEngine::checkClass);
+        return new NashornScriptEngineFactory().getScriptEngine(ARGS, getAppClassLoader(), CoreModScriptingEngine::checkClass);
     }
 
     private static ClassLoader getAppClassLoader() {

--- a/src/main/java/net/neoforged/coremod/transformer/CoreModBaseTransformer.java
+++ b/src/main/java/net/neoforged/coremod/transformer/CoreModBaseTransformer.java
@@ -37,7 +37,7 @@ public abstract class CoreModBaseTransformer<T> implements ITransformer<T> {
         try {
             result = runCoremod(result);
         } catch (Exception e) {
-            LOGGER.error(COREMOD, "Error occurred applying transform of coremod {} function {}", this.coreMod.getPath(), this.coreName, e);
+            LOGGER.error(COREMOD, "Error occurred applying transform of coremod {} function {}", this.coreMod.getDebugSource(), this.coreName, e);
         } finally {
             CoreModTracker.clearCoreMod();
         }

--- a/src/test/java/net/neoforged/coremod/CoreModTest.java
+++ b/src/test/java/net/neoforged/coremod/CoreModTest.java
@@ -12,7 +12,7 @@ public class CoreModTest {
     @SuppressWarnings("unchecked")
     @Test
     void testJSLoading() {
-        final CoreModEngine coreModEngine = new CoreModEngine();
+        final CoreModScriptingEngine coreModEngine = new CoreModScriptingEngine();
         coreModEngine.loadCoreMod(new JSFileLoader("src/test/javascript/testcoremod.js"));
         coreModEngine.loadCoreMod(new JSFileLoader("src/test/javascript/testcore2mod.js"));
         coreModEngine.loadCoreMod(new JSFileLoader("src/test/javascript/testdata.js"));

--- a/src/test/java/net/neoforged/coremod/JSFileLoader.java
+++ b/src/test/java/net/neoforged/coremod/JSFileLoader.java
@@ -6,7 +6,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-class JSFileLoader implements ICoreModFile {
+class JSFileLoader implements ICoreModScriptSource {
     private final Path path;
 
     JSFileLoader(final String path) {
@@ -23,11 +23,6 @@ class JSFileLoader implements ICoreModFile {
     }
 
     @Override
-    public Path getPath() {
-        return this.path;
-    }
-
-    @Override
     public Reader getAdditionalFile(final String fileName) throws IOException {
         return Files.newBufferedReader(this.path.getParent().resolve(fileName));
     }
@@ -35,5 +30,10 @@ class JSFileLoader implements ICoreModFile {
     @Override
     public String getOwnerId() {
         return "dummy";
+    }
+
+    @Override
+    public String getDebugSource() {
+        return path.toString();
     }
 }

--- a/src/test/java/net/neoforged/coremod/TestLaunchTransformer.java
+++ b/src/test/java/net/neoforged/coremod/TestLaunchTransformer.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 public class TestLaunchTransformer {
-    private static CoreModEngine cme = new CoreModEngine();
+    private static CoreModScriptingEngine cme = new CoreModScriptingEngine();
     public static List<ITransformer<?>> getTransformers() {
         return cme.initializeCoreMods();
     }


### PR DESCRIPTION
- Rename `ICoreModFile` to `ICoreModScriptSource` and `CoreModEngine` to `CoreModScriptingEngine`, to already prepare the naming for non-JS core mods.
- Remove direct `Path` usage, and replace by a debug source function (which is what the path was used for).